### PR TITLE
Fix: formula in 'x'd'y' dice returning unexpected blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install niwatori-dice
 const { NiwatoriDice } = require('niwatori-dice')
 const roll = NiwatoriDice()
 
-roll('1d100') // => { result: 60, verbose: [{ type: 'dice', formula: '1d100', reesult: 60, text:'' }] }
+roll('1d100') // => { result: 60, verbose: [{ type: 'dice', formula: '1d100', result: 60, text:'' }] }
 ```
 
 ### NiwatoriDice(oparators)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install niwatori-dice
 const { NiwatoriDice } = require('niwatori-dice')
 const roll = NiwatoriDice()
 
-roll('1d100') // => { result: 60, verbose: [{ type: 'dice', fomula: '1d100', reesult: 60, text:'' }] }
+roll('1d100') // => { result: 60, verbose: [{ type: 'dice', formula: '1d100', reesult: 60, text:'' }] }
 ```
 
 ### NiwatoriDice(oparators)
@@ -54,7 +54,7 @@ When fn runs it has references to `rand` and` verbose` through this.
 eg.
 ```js
 const { createVerbose } = require('niwatori-dice')
-// createVerbose(type, fomula, result, extendText)
+// createVerbose(type, formula, result, extendText)
 ...
 
 const roll = NiwatoriDice({
@@ -71,7 +71,7 @@ const roll = NiwatoriDice({
 })
 
 roll('fortune')
-// => { result: 5, verbose: [{ type: 'original', fomula: 'fortune', result: 5, text: 'You are 5 stars.' }] }
+// => { result: 5, verbose: [{ type: 'original', formula: 'fortune', result: 5, text: 'You are 5 stars.' }] }
 ```
 
 ##### oparators[].argLen (default: 2)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const CRC32 = require('crc-32')
 
-function createFomulaRegExpString(operators) {
+function createFormulaRegExpString(operators) {
   const commons = ['\\(', '\\)', ',', '".+?"', "'.+?'", '\\d+']
   const keys = Object.keys(operators).map((key) => {
     return key.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
@@ -23,9 +23,9 @@ function format(input, data) {
 }
 
 function tokenize(input, operators) {
-  const fomula = createFomulaRegExpString(operators)
-  const picker = new RegExp(`^${fomula}+(\\s|$)`, 'g')
-  const separator = new RegExp(fomula, 'g')
+  const formula = createFormulaRegExpString(operators)
+  const picker = new RegExp(`^${formula}+(\\s|$)`, 'g')
+  const separator = new RegExp(formula, 'g')
   const matches = input.match(picker)
   if (matches) {
     return matches[0].match(separator).map((token) => {

--- a/src/plugins/basic.js
+++ b/src/plugins/basic.js
@@ -41,7 +41,7 @@ module.exports = {
       }
       res.forEach((r, i) => verbose.push(createVerbose(
         `dice ${b}`,
-        `${a}d${b}` + res.length > 1 ? `#${i+1}` : '',
+        `${a}d${b}` + (res.length > 1 ? `#${i+1}` : ''),
         r
       )))
       const val = res.reduce((current, num) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,18 +25,25 @@ test('1+2*4', () => {
 })
 
 test('(1+2)*4', () => {
-  expect(roll('(1+2)*4', {}, TEST_SEED_1D100_60).result).toBe(12)
+  const dice = roll('(1+2)*4', {}, TEST_SEED_1D100_60)
+  expect(dice.result).toBe(12)
 })
 
 test('1d100', () => {
-  expect(roll('1d100', {}, TEST_SEED_1D100_60).result).toBe(60)
+  const dice = roll('1d100', {}, TEST_SEED_1D100_60)
+  expect(dice.result).toBe(60)
+  expect(dice.verbose[0].formula).toBe('1d100')
 })
 
 test('3d3', () => {
   const dice = roll('3d3', {}, TEST_SEED_1D100_60)
   expect(dice.verbose[0].result).toBe(2)
+  expect(dice.verbose[0].formula).toBe('3d3#1')
   expect(dice.verbose[1].result).toBe(1)
+  expect(dice.verbose[1].formula).toBe('3d3#2')
   expect(dice.verbose[2].result).toBe(1)
+  expect(dice.verbose[2].formula).toBe('3d3#3')
+
 })
 
 test('1d100<={DEX}*5', () => {
@@ -45,6 +52,7 @@ test('1d100<={DEX}*5', () => {
   }, TEST_SEED_1D100_60)
   expect(dice.result).toBe(false)
   expect(dice.verbose[0].result).toBe(60)
+  expect(dice.verbose[0].formula).toBe('1d100')
 })
 
 test('1d100<={dex}*5', () => {
@@ -53,6 +61,7 @@ test('1d100<={dex}*5', () => {
   }, TEST_SEED_1D100_60)
   expect(dice.result).toBe(false)
   expect(dice.verbose[0].result).toBe(60)
+  expect(dice.verbose[0].formula).toBe('1d100')
 })
 
 test('choice("a", "b", "c")', () => {

--- a/test/plugins/coc.test.js
+++ b/test/plugins/coc.test.js
@@ -12,39 +12,47 @@ const TEST_SEED_1D100_1 = 1538480153094
 
 describe('syntax', () => {
   let commands = ['cc', 'ccb', 'ＣＣ', 'ＣＣＢ']
+  let replacedCommands = ['cc', 'ccb', 'cc', 'ccb']
   let dice_eyes = TEST_SEED_1D100_15
 
   for(var i = 0, j = commands.length; i < j; i++){
     var command = commands[i]
+    var replacedCommand = replacedCommands[i]
 
     test(command, () => {
       const dice = roll(command, {}, dice_eyes)
       expect(dice.result).toBeUndefined()
+      expect(dice.verbose[0]).toBeUndefined()
     })
 
     test(command + '<=1', () => {
       const dice = roll(command + '<=1', {}, dice_eyes)
       expect(dice.result).toBeFalsy()
+      expect(dice.verbose[0].formula).toBe(replacedCommand + '<=1')
     })
 
     test(command + '<=1 TEXT', () => {
       const dice = roll(command + '<=1 TEXT', {}, dice_eyes)
       expect(dice.result).toBeFalsy()
+      expect(dice.verbose[0].formula).toBe(replacedCommand + '<=1')
     })
 
     test(command + '<=1 DEX*5', () => {
       const dice = roll(command + '<=1 DEX*5', {}, dice_eyes)
       expect(dice.result).toBeFalsy()
+      expect(dice.verbose[0].formula).toBe(replacedCommand + '<=1')
     })
 
     test('TEXT ' + command, () => {
       const dice = roll('TEXT ' + command, {}, dice_eyes)
       expect(dice.result).toBeUndefined()
+      expect(dice.verbose[0]).toBeUndefined()
     })
 
     test(command+'＜＝１', () => {
       const dice = roll(command + '＜＝１', {}, dice_eyes)
       expect(dice.result).toBeFalsy()
+      expect(dice.verbose[0].formula).toBe(replacedCommand + '<=1')
     })
   }
 })


### PR DESCRIPTION
This PR is the fix for formula in 'x'd'y' dice returning unexpected blank string. And I fixed some related typo .